### PR TITLE
Improve locale detection

### DIFF
--- a/js/langDetect.js
+++ b/js/langDetect.js
@@ -1,8 +1,11 @@
 (function () {
-  const LOCALE_TRAD = /^(zh-(TW|HK|MO))/i;
+  const LOCALE_TRAD = /^zh(?:[-_](?:TW|HK|MO|HANT))/i;
   const onTwPath    = /^\/tw(\/|$)/i.test(location.pathname);
 
-  if (LOCALE_TRAD.test(navigator.language || navigator.userLanguage)) {
+  const lang = (navigator.languages && navigator.languages[0]) ||
+               navigator.language;
+
+  if (LOCALE_TRAD.test(lang)) {
     if (!onTwPath) {
       const newPath = '/tw' + (location.pathname.replace(/\/$/, '') || '') + (location.pathname.endsWith('/') ? '/' : '');
       location.replace(newPath);


### PR DESCRIPTION
## Summary
- extend language detection regex to support `zh-Hant` and underscores
- check the first entry of `navigator.languages` if available

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6871e8614440832d9ce4b423402beaeb