### PR TITLE
Fix Tw redirection handling

### DIFF
--- a/js/langDetect.js
+++ b/js/langDetect.js
@@ -1,16 +1,37 @@
+/**
+ * Language detection and redirection helper.
+ *
+ * Redirects Traditional Chinese users to the `/tw/` path **within** the current
+ * base directory. The previous implementation prefixed the entire path with
+ * `/tw`, resulting in URLs like `/tw/zangli/`. This updated logic extracts the
+ * directory part of the current path (e.g. `/zangli/`) and inserts `tw/` after
+ * it, producing `/zangli/tw/`.
+ */
 (function () {
   const LOCALE_TRAD = /^(zh-(TW|HK|MO))/i;
-  const onTwPath    = /^\/tw(\/|$)/i.test(location.pathname);
 
-  if (LOCALE_TRAD.test(navigator.language || navigator.userLanguage)) {
+  const baseMatch = location.pathname.match(/^\/[^\/]*\//);
+  const basePath  = baseMatch ? baseMatch[0] : '/';
+  const twPrefix  = basePath + 'tw/';
+  const onTwPath  = new RegExp('^' + twPrefix.replace(/\//g, '\\/'), 'i')
+    .test(location.pathname);
+
+  const browserLang = (navigator.languages && navigator.languages[0]) ||
+                      navigator.language || navigator.userLanguage;
+
+  function redirect(path) {
+    location.replace(path + location.search + location.hash);
+  }
+
+  if (LOCALE_TRAD.test(browserLang)) {
     if (!onTwPath) {
-      const newPath = '/tw' + (location.pathname.replace(/\/$/, '') || '') + (location.pathname.endsWith('/') ? '/' : '');
-      location.replace(newPath);
+      const newPath = twPrefix + location.pathname.slice(basePath.length);
+      redirect(newPath);
     }
   } else {
     if (onTwPath) {
-      const newPath = location.pathname.replace(/^\/tw\/?/, '/');
-      location.replace(newPath || '/');
+      const newPath = basePath + location.pathname.slice(twPrefix.length);
+      redirect(newPath);
     }
   }
-})(); 
+})();


### PR DESCRIPTION
## Summary
- update language detection to rely on `navigator.languages`
- insert `/tw/` inside the current directory instead of before it
- keep `location.search` and `location.hash` when redirecting
- adjust reverse redirects accordingly

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6871e85fe1a0832dbea2bc9423641bed