### PR TITLE
Fix Today button margin on mobile view

### DIFF
--- a/index.html
+++ b/index.html
@@ -596,12 +596,12 @@
 					max-width: 200px;
 				}
 
-				.today-btn {
-					width: 100%;
-					max-width: 200px;
-					margin-top: 10px;
-				}
-			}
+                                .today-btn {
+                                        width: 100%;
+                                        max-width: 200px;
+                                        margin-top: 0;
+                                }
+                        }
 
 			@media (max-width: 480px) {
 				.calendar-table td {


### PR DESCRIPTION
## Summary
- remove extra margin-top from `.today-btn` style in mobile breakpoint

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6873f7548154832d90040dbf8c2c0682